### PR TITLE
Fixes #24 and Fixes #23

### DIFF
--- a/ITSP-TrackingSystemRefactor/ITSP-TrackingSystemRefactor.vbproj.user
+++ b/ITSP-TrackingSystemRefactor/ITSP-TrackingSystemRefactor.vbproj.user
@@ -10,7 +10,7 @@
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
     <UseGlobalApplicationHostFile />
-    <LastActiveSolutionConfig>Debug|Any CPU</LastActiveSolutionConfig>
+    <LastActiveSolutionConfig>Release|Any CPU</LastActiveSolutionConfig>
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>

--- a/ITSP-TrackingSystemRefactor/My Project/PublishProfiles/DLS-Release.pubxml.user
+++ b/ITSP-TrackingSystemRefactor/My Project/PublishProfiles/DLS-Release.pubxml.user
@@ -30,13 +30,13 @@ by editing this MSBuild file. In order to learn more about this please visit htt
       <publishTime>09/10/2013 16:29:20</publishTime>
     </File>
     <File Include="bin/App_Browsers.dll">
-      <publishTime>02/01/2021 08:59:40</publishTime>
+      <publishTime>02/23/2021 09:17:13</publishTime>
     </File>
     <File Include="bin/App_global.asax.compiled">
-      <publishTime>02/01/2021 08:59:38</publishTime>
+      <publishTime>02/23/2021 09:17:11</publishTime>
     </File>
     <File Include="bin/App_global.asax.dll">
-      <publishTime>02/01/2021 08:59:38</publishTime>
+      <publishTime>02/23/2021 09:17:11</publishTime>
     </File>
     <File Include="bin/AspNet.ScriptManager.bootstrap.dll">
       <publishTime>05/19/2020 09:11:00</publishTime>
@@ -324,13 +324,13 @@ by editing this MSBuild file. In order to learn more about this please visit htt
       <publishTime>06/21/2016 09:54:42</publishTime>
     </File>
     <File Include="bin/ITSP-TrackingSystemRefactor.dll">
-      <publishTime>02/01/2021 08:59:21</publishTime>
+      <publishTime>02/23/2021 09:16:43</publishTime>
     </File>
     <File Include="bin/ITSP-TrackingSystemRefactor.pdb">
-      <publishTime>02/01/2021 08:59:21</publishTime>
+      <publishTime>02/23/2021 09:16:43</publishTime>
     </File>
     <File Include="bin/ITSP-TrackingSystemRefactor.XmlSerializers.dll">
-      <publishTime>02/01/2021 08:59:24</publishTime>
+      <publishTime>02/23/2021 09:16:49</publishTime>
     </File>
     <File Include="bin/ja/DevExpress.Data.v19.2.resources.dll">
       <publishTime>04/01/2020 20:00:31</publishTime>
@@ -792,13 +792,13 @@ by editing this MSBuild file. In order to learn more about this please visit htt
       <publishTime>02/11/2014 14:26:04</publishTime>
     </File>
     <File Include="bin/WebForms_Basic.xml">
-      <publishTime>02/01/2021 08:59:19</publishTime>
+      <publishTime>02/23/2021 09:16:42</publishTime>
     </File>
     <File Include="bin/WebGrease.dll">
       <publishTime>01/23/2014 13:57:34</publishTime>
     </File>
     <File Include="bin/__browserCapabilitiesCompiler.compiled">
-      <publishTime>02/01/2021 08:59:40</publishTime>
+      <publishTime>02/23/2021 09:17:13</publishTime>
     </File>
     <File Include="BulkImport.xsc">
       <publishTime>05/03/2019 08:24:14</publishTime>
@@ -3417,7 +3417,7 @@ by editing this MSBuild file. In order to learn more about this please visit htt
       <publishTime>07/29/2020 14:29:42</publishTime>
     </File>
     <File Include="PrecompiledApp.config">
-      <publishTime>02/01/2021 08:59:27</publishTime>
+      <publishTime>02/23/2021 09:16:52</publishTime>
     </File>
     <File Include="prelogindata.xsc">
       <publishTime>05/04/2020 09:14:07</publishTime>
@@ -3444,7 +3444,7 @@ by editing this MSBuild file. In order to learn more about this please visit htt
       <publishTime>04/02/2020 09:36:26</publishTime>
     </File>
     <File Include="scoplayer/Lib/API.js">
-      <publishTime>01/05/2021 14:59:40</publishTime>
+      <publishTime>02/17/2021 14:06:00</publishTime>
     </File>
     <File Include="scoplayer/Lib/API_1484_11.js">
       <publishTime>05/09/2019 10:28:14</publishTime>
@@ -3483,7 +3483,7 @@ by editing this MSBuild file. In order to learn more about this please visit htt
       <publishTime>05/09/2019 10:28:14</publishTime>
     </File>
     <File Include="scoplayer/sco.aspx">
-      <publishTime>01/25/2021 10:42:40</publishTime>
+      <publishTime>02/02/2021 09:41:31</publishTime>
     </File>
     <File Include="Scripts/adminreg.js">
       <publishTime>05/05/2020 16:26:39</publishTime>
@@ -4182,7 +4182,7 @@ by editing this MSBuild file. In order to learn more about this please visit htt
       <publishTime>02/08/2019 15:59:44</publishTime>
     </File>
     <File Include="Web.config">
-      <publishTime>02/01/2021 08:59:26</publishTime>
+      <publishTime>02/02/2021 09:20:24</publishTime>
     </File>
   </ItemGroup>
 </Project>

--- a/ITSP-TrackingSystemRefactor/cms/ManageContent.aspx.vb
+++ b/ITSP-TrackingSystemRefactor/cms/ManageContent.aspx.vb
@@ -110,6 +110,7 @@ Public Class ManageContent
                 Dim fPath As String = fPathBase & "Course" + Page.Request.Item("courseid").ToString() + "\"
                 fPath = fPath & "Section" + e.CommandArgument.ToString() + "\"
                 If Directory.Exists(fPath) Then
+                    RemoveFileAttributes(fPath)
                     Directory.Delete(fPath, True)
                 End If
                 Dim taSec As New itspdbTableAdapters.SectionsTableAdapter
@@ -715,12 +716,14 @@ Public Class ManageContent
                             'we need to delete the containing folder:
                             Dim sPath As String = sOldPath.Substring(0, sOldPath.LastIndexOf("\"))
                             If Directory.Exists(sPath) Then
+                                RemoveFileAttributes(sPath)
                                 Directory.Delete(sPath, True)
                                 bContentDeleted = True
                             End If
                         Else
                             'we need to delete the file:
                             If File.Exists(sOldPath) Then
+                                RemoveFileAttributes(sOldPath)
                                 File.Delete(sOldPath)
                                 bContentDeleted = True
 
@@ -735,6 +738,12 @@ Public Class ManageContent
         End If
         Return bContentDeleted
     End Function
+    Public Shared Sub RemoveFileAttributes(ByVal target_dir As String)
+        Dim files As String() = Directory.GetFiles(target_dir)
+        For Each sFile In files
+            File.SetAttributes(sFile, FileAttributes.Normal)
+        Next
+    End Sub
     Protected Function CorrectTutorialURL(ByVal sURL As String) As String
         If sURL.StartsWith("/cms/CMSContent") Then
             sURL = My.Settings.MyURL & sURL

--- a/ITSP-TrackingSystemRefactor/scoplayer/Lib/API.js
+++ b/ITSP-TrackingSystemRefactor/scoplayer/Lib/API.js
@@ -171,7 +171,7 @@ function ITSPSetValue(e, v) {
 	            dataType: String
 	        });
         }
-        if (v === "") {
+        else if (v === "") {
             //Store complete
             window.parent.closeMpe();
         }


### PR DESCRIPTION
#24: Prevents closing of SCORM post learning content when a cms.core.exit call is made with no value.
#23: Adds sub routine to mark all files in directory as "normal" (i.e. not read only) before deleting the directory.