### PR TITLE
#119 Redirects in place for login, app select and landing

### DIFF
--- a/ITSP-TrackingSystemRefactor/My Project/Settings.Designer.vb
+++ b/ITSP-TrackingSystemRefactor/My Project/Settings.Designer.vb
@@ -15,7 +15,7 @@ Option Explicit On
 Namespace My
     
     <Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
-     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0"),  _
+     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0"),  _
      Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>  _
     Partial Friend NotInheritable Class MySettings
         Inherits Global.System.Configuration.ApplicationSettingsBase
@@ -139,10 +139,19 @@ Namespace My
         
         <Global.System.Configuration.ApplicationScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("https://www.dls.nhs.uk/dev-my-learning-portal/LearningPortal/Current")>  _
+         Global.System.Configuration.DefaultSettingValueAttribute("https://localhost:44363/LearningPortal/Current")>  _
         Public ReadOnly Property LearningPortalURL() As String
             Get
                 Return CType(Me("LearningPortalURL"),String)
+            End Get
+        End Property
+        
+        <Global.System.Configuration.ApplicationScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("https://localhost:44363/")>  _
+        Public ReadOnly Property RefactoredAppBaseURL() As String
+            Get
+                Return CType(Me("RefactoredAppBaseURL"),String)
             End Get
         End Property
     End Class

--- a/ITSP-TrackingSystemRefactor/My Project/Settings.settings
+++ b/ITSP-TrackingSystemRefactor/My Project/Settings.settings
@@ -35,7 +35,10 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="LearningPortalURL" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">https://www.dls.nhs.uk/dev-my-learning-portal/LearningPortal/Current</Value>
+      <Value Profile="(Default)">https://localhost:44363/LearningPortal/Current</Value>
+    </Setting>
+    <Setting Name="RefactoredAppBaseURL" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">https://localhost:44363/</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/ITSP-TrackingSystemRefactor/Web.config
+++ b/ITSP-TrackingSystemRefactor/Web.config
@@ -20,9 +20,9 @@
   <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <connectionStrings>
-      <add name="ITSP_TrackingSystemRefactor.My.MySettings.csITSPDB"
-          connectionString="Data Source=localhost;Initial Catalog=mbdbx101;Integrated Security=True"
-          providerName="System.Data.SqlClient" />
+    <add name="ITSP_TrackingSystemRefactor.My.MySettings.csITSPDB"
+      connectionString="Data Source=localhost;Initial Catalog=mbdbx101;Integrated Security=True"
+      providerName="System.Data.SqlClient" />
   </connectionStrings>
   <system.web.extensions>
     <scripting>
@@ -182,34 +182,37 @@
 	</appSettings>
   <applicationSettings>
     <ITSP_TrackingSystemRefactor.My.MySettings>
-        <setting name="RedirectLearnSco" serializeAs="String">
-            <value>False</value>
-        </setting>
-        <setting name="ShowLegacyLink" serializeAs="String">
-            <value>False</value>
-        </setting>
-        <setting name="ITSPTrackingURL" serializeAs="String">
-            <value>https://localhost:44367/tracking/</value>
-        </setting>
-        <setting name="LegacyURL" serializeAs="String">
-            <value>https://localhost:44367/tracking/</value>
-        </setting>
-        <setting name="MyURL" serializeAs="String">
-            <value>https://localhost:44367/</value>
-        </setting>
-        <setting name="ITSP_TrackingSystemRefactor_ts_services_services"
-            serializeAs="String">
-            <value>https://localhost:44367/services.asmx</value>
-        </setting>
-        <setting name="CMSRepo" serializeAs="String">
-            <value>https://localhost:44367/cms/cms-content</value>
-        </setting>
-        <setting name="AllowAzureSSO" serializeAs="String">
-            <value>True</value>
-        </setting>
-        <setting name="LearningPortalURL" serializeAs="String">
-            <value>https://localhost:44363/LearningPortal/Current</value>
-        </setting>
+      <setting name="RedirectLearnSco" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="ShowLegacyLink" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="ITSPTrackingURL" serializeAs="String">
+        <value>https://localhost:44367/tracking/</value>
+      </setting>
+      <setting name="LegacyURL" serializeAs="String">
+        <value>https://localhost:44367/tracking/</value>
+      </setting>
+      <setting name="MyURL" serializeAs="String">
+        <value>https://localhost:44367/</value>
+      </setting>
+      <setting name="ITSP_TrackingSystemRefactor_ts_services_services"
+        serializeAs="String">
+        <value>https://localhost:44367/services.asmx</value>
+      </setting>
+      <setting name="CMSRepo" serializeAs="String">
+        <value>https://localhost:44367/cms/cms-content</value>
+      </setting>
+      <setting name="AllowAzureSSO" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="LearningPortalURL" serializeAs="String">
+        <value>https://localhost:44363/LearningPortal/Current</value>
+      </setting>
+      <setting name="RefactoredAppBaseURL" serializeAs="String">
+        <value>https://localhost:44363/</value>
+      </setting>
     </ITSP_TrackingSystemRefactor.My.MySettings>
   </applicationSettings>
   <entityFramework>

--- a/ITSP-TrackingSystemRefactor/controls/usermx.ascx
+++ b/ITSP-TrackingSystemRefactor/controls/usermx.ascx
@@ -2,8 +2,10 @@
 <%--<a href="javascript:void(0)" class="btn-circle btn-circle-primary no-focus animated zoomInDown animation-delay-8" data-toggle="modal" data-target="#ms-account-modal">
                                 <i class="fas fa-user"></i>
                             </a>--%>
-<asp:LinkButton ID="lbtAccount" aria-label="Login or Register" CssClass="no-focus animated zoomInDown animation-delay-5" data-toggle="modal" data-target="#pnlAccount" runat="server"><i class="fas fa-user"></i></asp:LinkButton>
-<asp:LinkButton ID="lbtAppSelect" aria-label="Switch between Digital Learning Solutions applications" Visible="false" CssClass="no-focus text-primary-lp animated tada animation-delay-5" data-toggle="modal" data-target="#pnlAppSelect" runat="server"><i class="fas fa-th-large"></i>&nbsp;<i class="fas fa-ellipsis-v"></i></asp:LinkButton>
+<asp:HyperLink ID="hlAccount" aria-label="Login or Register" CssClass="no-focus animated zoomInDown animation-delay-5" runat="server"><i class="fas fa-user"></i></asp:HyperLink>
+<asp:HyperLink ID="hlAppSelect" aria-label="Switch between Digital Learning Solutions applications" Visible="false" CssClass="no-focus text-primary-lp animated tada animation-delay-5" runat="server"><i class="fas fa-th-large"></i>&nbsp;<i class="fas fa-ellipsis-v"></i></asp:HyperLink>
+<%--<asp:LinkButton ID="lbtAccount" aria-label="Login or Register" CssClass="no-focus animated zoomInDown animation-delay-5" runat="server"><i class="fas fa-user"></i></asp:LinkButton>
+<asp:LinkButton ID="lbtAppSelect" aria-label="Switch between Digital Learning Solutions applications" Visible="false" CssClass="no-focus text-primary-lp animated tada animation-delay-5" runat="server"><i class="fas fa-th-large"></i>&nbsp;<i class="fas fa-ellipsis-v"></i></asp:LinkButton>--%>
 <!-- Modal -->
 
           

--- a/ITSP-TrackingSystemRefactor/controls/usermx.ascx.designer.vb
+++ b/ITSP-TrackingSystemRefactor/controls/usermx.ascx.designer.vb
@@ -12,22 +12,22 @@ Option Explicit On
 
 
 Partial Public Class usermx
-    
+
     '''<summary>
-    '''lbtAccount control.
+    '''hlAccount control.
     '''</summary>
     '''<remarks>
     '''Auto-generated field.
     '''To modify move field declaration from designer file to code-behind file.
     '''</remarks>
-    Protected WithEvents lbtAccount As Global.System.Web.UI.WebControls.LinkButton
-    
+    Protected WithEvents hlAccount As Global.System.Web.UI.WebControls.HyperLink
+
     '''<summary>
-    '''lbtAppSelect control.
+    '''hlAppSelect control.
     '''</summary>
     '''<remarks>
     '''Auto-generated field.
     '''To modify move field declaration from designer file to code-behind file.
     '''</remarks>
-    Protected WithEvents lbtAppSelect As Global.System.Web.UI.WebControls.LinkButton
+    Protected WithEvents hlAppSelect As Global.System.Web.UI.WebControls.HyperLink
 End Class

--- a/ITSP-TrackingSystemRefactor/controls/usermx.ascx.vb
+++ b/ITSP-TrackingSystemRefactor/controls/usermx.ascx.vb
@@ -2,7 +2,8 @@
     Inherits System.Web.UI.UserControl
     Protected Property bUserAuth As Boolean = False
     Protected Sub Page_Load(ByVal sender As Object, ByVal e As System.EventArgs) Handles Me.Load
-
+        hlAccount.NavigateUrl = My.Settings.RefactoredAppBaseURL + "Login"
+        hlAppSelect.NavigateUrl = My.Settings.RefactoredAppBaseURL + "ApplicationSelector"
     End Sub
 
     Private Sub usermx_Init(sender As Object, e As EventArgs) Handles Me.Init
@@ -12,15 +13,15 @@
     Private Sub usermx_PreRender(sender As Object, e As EventArgs) Handles Me.PreRender
         If Not Session("UserAdminID") Is Nothing Then
             If Session("UserAdminID") > 0 Then
-                lbtAccount.Visible = False
-                lbtAppSelect.Visible = True
+                hlAccount.Visible = False
+                hlAppSelect.Visible = True
             End If
         End If
 
         If Not Session("learnUserAuthenticated") Is Nothing Then
             If Session("learnUserAuthenticated") Then
-                lbtAccount.Visible = False
-                lbtAppSelect.Visible = True
+                hlAccount.Visible = False
+                hlAppSelect.Visible = True
             End If
         End If
     End Sub

--- a/ITSP-TrackingSystemRefactor/home.aspx.vb
+++ b/ITSP-TrackingSystemRefactor/home.aspx.vb
@@ -2,6 +2,13 @@
     Inherits System.Web.UI.Page
 
     Protected Sub Page_Load(ByVal sender As Object, ByVal e As System.EventArgs) Handles Me.Load
+        'Redirect to V2 login page:
+
+        If Not Request.IsAuthenticated Then
+            Dim LoginURL As String = My.Settings.RefactoredAppBaseURL + "Home/Welcome"
+            Response.Redirect(LoginURL)
+        End If
+
         If Not Page.IsPostBack Then
             Dim taHL As New prelogindataTableAdapters.HeadlineFiguresTableAdapter
             Dim tHL As New prelogindata.HeadlineFiguresDataTable
@@ -18,6 +25,8 @@
             If Session("UserCentreID") > 0 Then
                 pnlLogin.Visible = False
                 pnlAppSelect.Visible = True
+                Dim appSelectorURL As String = My.Settings.RefactoredAppBaseURL + "ApplicationSelector"
+                Response.Redirect(appSelectorURL)
             End If
         End If
     End Sub


### PR DESCRIPTION
This doesn't include links on each TS page mentioned in the issue - considered overkill given that the app selector redirects to the new app selector.

We need to ensure that the new web.config appsetting RefactoredAppBaseURL is included in the dev-prev and live web config (with appropriate values).