### PR TITLE
TD-2251 Removes help link and associated code from support tab

### DIFF
--- a/ITSP-TrackingSystemRefactor/tracking/Site.Master
+++ b/ITSP-TrackingSystemRefactor/tracking/Site.Master
@@ -282,14 +282,7 @@
                                 <uc1:usermx runat="server" class="nav-link" ID="usermx" />
                             </li>
                         </ul>
-
                     </div>
-                    <div class="form-inline my-2 my-lg-0">
-
-                        <asp:HyperLink ID="hlHelpBtn" CssClass="nav-item btn btn-circle-lg btn-outline-light my-2 my-sm-0" ToolTip="Help" Target="_blank" runat="server" NavigateUrl="~/help/Introduction.html"><i class="fas fa-question"></i></asp:HyperLink>
-                    </div>
-
-
                 </div>
             </nav>
             <div class="container container-full">
@@ -371,8 +364,6 @@
                         <a class="collapsed" role="button" data-toggle="collapse" href="#sc4" aria-expanded="false" aria-controls="sc4">
                             <i class="fas fa-life-ring"></i>Support </a>
                         <ul id="sc4" class="card-collapse collapse" role="tabpanel" aria-labelledby="sch4" data-parent="#slidebar-menu">
-                            <li>
-                                <asp:HyperLink ID="hlHelp2" Target="_blank" CssClass="dropdown-item" runat="server" NavigateUrl="~/help/Introduction.html">Help</asp:HyperLink></li>
                             <li><a href="faqs" class="dropdown-item">FAQs</a></li>
                             <li runat="server" id="liTickets1"><a href="tickets" class="dropdown-item">Tickets</a></li>
                             <li><a href="resources" class="dropdown-item">Resources</a></li>

--- a/ITSP-TrackingSystemRefactor/tracking/Site.Master
+++ b/ITSP-TrackingSystemRefactor/tracking/Site.Master
@@ -256,8 +256,6 @@
                             <li id="liSupport" runat="server" class="nav-item dropdown">
                                 <a href="support" data-hover="dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="nav-link dropdown-toggle">Support <i class="fas fa-angle-down"></i></a>
                                 <ul class="dropdown-menu ddmain">
-                                    <li>
-                                        <asp:HyperLink ID="hlHelp" Target="_blank" CssClass="dropdown-item" runat="server" NavigateUrl="~/help/Introduction.html">Help</asp:HyperLink></li>
                                     <li><a href="faqs" class="dropdown-item">FAQs</a></li>
                                     <li runat="server" id="liTickets"><a href="tickets" class="dropdown-item">Tickets</a></li>
                                     <li><a href="resources" class="dropdown-item">Resources</a></li>

--- a/ITSP-TrackingSystemRefactor/tracking/Site.Master.designer.vb
+++ b/ITSP-TrackingSystemRefactor/tracking/Site.Master.designer.vb
@@ -230,15 +230,6 @@ Partial Public Class SiteMaster
     Protected WithEvents usermx As Global.ITSP_TrackingSystemRefactor.usermx
 
     '''<summary>
-    '''hlHelpBtn control.
-    '''</summary>
-    '''<remarks>
-    '''Auto-generated field.
-    '''To modify move field declaration from designer file to code-behind file.
-    '''</remarks>
-    Protected WithEvents hlHelpBtn As Global.System.Web.UI.WebControls.HyperLink
-
-    '''<summary>
     '''breadtray control.
     '''</summary>
     '''<remarks>
@@ -318,15 +309,6 @@ Partial Public Class SiteMaster
     '''To modify move field declaration from designer file to code-behind file.
     '''</remarks>
     Protected WithEvents sch4 As Global.System.Web.UI.HtmlControls.HtmlGenericControl
-
-    '''<summary>
-    '''hlHelp2 control.
-    '''</summary>
-    '''<remarks>
-    '''Auto-generated field.
-    '''To modify move field declaration from designer file to code-behind file.
-    '''</remarks>
-    Protected WithEvents hlHelp2 As Global.System.Web.UI.WebControls.HyperLink
 
     '''<summary>
     '''liTickets1 control.

--- a/ITSP-TrackingSystemRefactor/tracking/Site.Master.designer.vb
+++ b/ITSP-TrackingSystemRefactor/tracking/Site.Master.designer.vb
@@ -122,15 +122,6 @@ Partial Public Class SiteMaster
     Protected WithEvents liSupport As Global.System.Web.UI.HtmlControls.HtmlGenericControl
 
     '''<summary>
-    '''hlHelp control.
-    '''</summary>
-    '''<remarks>
-    '''Auto-generated field.
-    '''To modify move field declaration from designer file to code-behind file.
-    '''</remarks>
-    Protected WithEvents hlHelp As Global.System.Web.UI.WebControls.HyperLink
-
-    '''<summary>
     '''liTickets control.
     '''</summary>
     '''<remarks>

--- a/ITSP-TrackingSystemRefactor/tracking/Site.Master.vb
+++ b/ITSP-TrackingSystemRefactor/tracking/Site.Master.vb
@@ -71,42 +71,36 @@ Public Class SiteMaster
                         CCommon.AdminUserLogout()
                         Response.Redirect("~/Home?action=login&app=ts")
                     End If
-                    hlHelp.NavigateUrl = "~/help/Dashboard.html"
                     liCentre.Attributes.Add("class", "nav-item dropdown active")
                 Case "delegates"
                     If Not Session("UserCentreAdmin") Then
                         CCommon.AdminUserLogout()
                         Response.Redirect("~/Home?action=login&app=ts")
                     End If
-                    hlHelp.NavigateUrl = "~/help/AllDelegates.html"
                     liDelegates.Attributes.Add("class", "nav-item dropdown active")
                 Case "delegategroups"
                     If Not Session("UserCentreAdmin") Then
                         CCommon.AdminUserLogout()
                         Response.Redirect("~/Home?action=login&app=ts")
                     End If
-                    hlHelp.NavigateUrl = "~/help/AllDelegates.html"
                     liDelegates.Attributes.Add("class", "nav-item dropdown active")
                 Case "coursedelegates"
                     If Not Session("UserCentreAdmin") Then
                         CCommon.AdminUserLogout()
                         Response.Redirect("~/Home?action=login&app=ts")
                     End If
-                    hlHelp.NavigateUrl = "~/help/CourseDelegates.html"
                     liDelegates.Attributes.Add("class", "nav-item dropdown active")
                 Case "approvedelegates"
                     If Not Session("UserCentreAdmin") Then
                         CCommon.AdminUserLogout()
                         Response.Redirect("~/Home?action=login&app=ts")
                     End If
-                    hlHelp.NavigateUrl = "~/help/ApprovingDelegateRegistrations.html"
                     liDelegates.Attributes.Add("class", "nav-item dropdown active")
                 Case "coursesetup"
                     If Not Session("UserCentreAdmin") Then
                         CCommon.AdminUserLogout()
                         Response.Redirect("~/Home?action=login&app=ts")
                     End If
-                    hlHelp.NavigateUrl = "~/help/CourseSetup.html"
                     liCourseSetup.Attributes.Add("class", "nav-item active")
                 Case "sv-schedule"
                     If Not Session("IsSupervisor") Then
@@ -114,46 +108,37 @@ Public Class SiteMaster
                         Response.Redirect("~/Home?action=login&app=ts")
                     End If
                     liSupervisor.Attributes.Add("class", "nav-item dropdown active")
-                    hlHelp.NavigateUrl = "~/help/SuperviseDelegates.html"
                 Case "sv-schedule"
                     If Not Session("IsSupervisor") Then
                         CCommon.AdminUserLogout()
                         Response.Redirect("~/Home?action=login&app=ts")
                     End If
                     liSupervisor.Attributes.Add("class", "nav-item dropdown active")
-                    hlHelp.NavigateUrl = "~/help/ScheduleBeta.html"
                 Case "centrelogins"
                     If Not Session("UserCentreManager") Then
                         CCommon.AdminUserLogout()
                         Response.Redirect("~/Home?action=login&app=ts")
                     End If
-                    hlHelp.NavigateUrl = "~/help/ApprovingaCentreUserRegistration.html"
                     liCentre.Attributes.Add("class", "nav-item dropdown active")
                 Case "learningportal"
-                    hlHelp.NavigateUrl = "~/help/LearningPortalConfiguration.html"
                     liCentre.Attributes.Add("class", "nav-item dropdown active")
                 Case "resources"
-                    hlHelp.NavigateUrl = "~/help/Resources.html"
                     liSupport.Attributes.Add("class", "nav-item dropdown active")
                 Case "reports"
-                    hlHelp.NavigateUrl = "~/help/Reports.html"
                     liCentre.Attributes.Add("class", "nav-item dropdown active")
                 Case "reportfwa"
                     If Not Session("UserCentreReports") Then
                         CCommon.AdminUserLogout()
                         Response.Redirect("~/Home?action=login&app=ts")
                     End If
-                    hlHelp.NavigateUrl = "~/help/Reports.html"
                     liCentre.Attributes.Add("class", "nav-item dropdown active")
                 Case "faqs", "tickets"
-                    hlHelp.NavigateUrl = "~/help/FAQs.html"
                     liSupport.Attributes.Add("class", "nav-item dropdown active")
                 Case "tickets"
                     If Not Session("UserCentreAdmin") And Not Session("UserUserAdmin") Then
                         CCommon.AdminUserLogout()
                         Response.Redirect("~/Home?action=login&app=ts")
                     End If
-                    hlHelp.NavigateUrl = "~/help/SupportTickets.html"
                     liSupport.Attributes.Add("class", "nav-item dropdown active")
                 Case "statsdetail"
                     If Not Session("UserUserAdmin") And Not Session("UserSummaryReports") Then
@@ -171,7 +156,6 @@ Public Class SiteMaster
                     End If
                     liAdmin.Attributes.Add("class", "nav-item dropdown active")
             End Select
-            hlHelpBtn.NavigateUrl = hlHelp.NavigateUrl
         End If
 
         '


### PR DESCRIPTION
### JIRA link
[TD-2251](https://hee-tis.atlassian.net/browse/TD-2251)

### Description
Removes the Help link from the Support dropdown on the nav menu in the master site template. Also removes all references to the link from the codebehind file.

### Screenshots
Desktop:
![image](https://github.com/TechnologyEnhancedLearning/DLS-LEGACY/assets/67740339/996ef47e-a06e-465c-a5e3-9723c2040ca4)

Mobile:
![image](https://github.com/TechnologyEnhancedLearning/DLS-LEGACY/assets/67740339/02e08bce-c908-4399-99f1-cbd2b2e4c08e)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors (see [info on Text Editor settings](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546185813/DLS+Dev+Process) to avoid whitespace changes)
- [ ] Written tests for the changes (accessibility tests, unit tests for controller, data services, services, view models, etc)
- [x] Manually tested my work with and without JavaScript
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3546939432/DLS+Code) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/DLSV2/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing’s broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.

[TD-2251]: https://hee-tis.atlassian.net/browse/TD-2251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ