### PR TITLE
TD-3027 LMS commit return true

### DIFF
--- a/ITSP-TrackingSystemRefactor/scoplayer/Lib/API.js
+++ b/ITSP-TrackingSystemRefactor/scoplayer/Lib/API.js
@@ -121,6 +121,7 @@ API.LMSCommit = function (param) {
                 dataType: String
             });
         }
+        return true;
     }
     else {
         return API.$0.LMSCommit(param);


### PR DESCRIPTION
Returns true in the LMSCommit function. The lack of a return value was causing the player to crash for some SCOs.